### PR TITLE
Update the webpack config, leave the build directory checked in

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,8 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js?$/,
-        exclude: /(node_modules)/,
+        test: /\.(js|jsx)?$/,
+        exclude:path.resolve(__dirname, "node_modules"),
         use: 'babel-loader',
       },
     ],


### PR DESCRIPTION
Turns out we needed the build directory checked in, or otherwise the node modules trick doesn't work.  So, while it's ugly, it seems like a necessary evil.  I've force pushed develop to go back in time and restore the build directory so I'm making another PR to get the webpack changes in place