### PR TITLE
add prepare step to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "scripts/watch.sh",
     "test": "mocha --compilers js:@babel/register --recursive test",
     "test:watch": "nodemon -x \"mocha --compilers js:@babel/register --recursive --watch test\" -w test -w build",
-    "watch": "webpack --watch"
+    "watch": "webpack --watch",
+    "prepare" : "npm run build"
   },
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
To allow this github repo to be used as a npm dependency, we add a prepare step that creates a build of this repo. 