### PR TITLE
expose q and fq solr query param values in solr query module

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -41,10 +41,8 @@ server.performXhr = function (options, accept, reject = function () {
 
 server.submitQuery = (query, callback) => {
   callback({type: "SET_RESULTS_PENDING"});
-
   const queryString = solrQuery(query);
   const options = getXHROptions(query, queryString);
-
   server.performXhr(options, (err, resp) => {
     if (resp.statusCode >= 200 && resp.statusCode < 300) {
       callback({type: "SET_RESULTS", data: JSON.parse(resp.body)});
@@ -70,7 +68,6 @@ server.submitSuggestQuery = (suggestQuery, callback) => {
 };
 
 server.fetchCsv = (query, callback) => {
-
   const queryString = solrQuery({...query, rows: MAX_INT}, {wt: "csv"});
   const options = getXHROptions(query, queryString);
 


### PR DESCRIPTION
Expose the q and fq solr query param values in the solr query module, so the isamples client can use  `getQFQSolrQueryParamValues` to get the current q and fq solr query param values. 